### PR TITLE
Fix fallback strings typo

### DIFF
--- a/shared/NdGameSdk/components/SdkModule.cpp
+++ b/shared/NdGameSdk/components/SdkModule.cpp
@@ -60,8 +60,8 @@ namespace NdGameSdk {
 				return SdkModule->second;
 			}
 
-			throw SdkModuleException("Module " + get_module_name(ActionModule).value_or("UNKNOW") + "is not registered in SDK!",
-				SdkModuleException::ErrorCode::NotRegistered);
+                        throw SdkModuleException("Module " + get_module_name(ActionModule).value_or("UNKNOWN") + "is not registered in SDK!",
+                                SdkModuleException::ErrorCode::NotRegistered);
 		}
 
 		return nullptr;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -24,7 +24,7 @@ BOOL Initialize(HMODULE dllModule) {
     HMODULE baseModule = GetModuleHandle(NULL);
     std::string moduleName = Utility::memory::get_module_name(baseModule).value();
     std::wstring exePath = Utility::memory::get_module_pathw(baseModule).value();
-    std::wstring VerProductName = Utility::memory::get_version_product_name(baseModule).value_or(L"UNKNOW");
+    std::wstring VerProductName = Utility::memory::get_version_product_name(baseModule).value_or(L"UNKNOWN");
 
     if (moduleName != std::string(GAME_MODULE_NAME) ||
         !Utils::Config::InitDefaultConfig()) {


### PR DESCRIPTION
## Summary
- fix fallback typos for unknown module names

## Testing
- `cmake --version`
- `cmake -S . -B build` *(fails: unable to fetch cmkr)*

------
https://chatgpt.com/codex/tasks/task_e_6840d1758d848322a1e2052c1ac1e42b